### PR TITLE
Bugfix: SIM profile update & ICCID read

### DIFF
--- a/drivers/atmodem/sim.c
+++ b/drivers/atmodem/sim.c
@@ -81,6 +81,9 @@ static const char *sind_prefix[] = { "^SIND:", NULL };
 static const char *csim_prefix[] = { "+CSIM:", NULL };
 static const char *none_prefix[] = { NULL };
 
+static void at_read_simstatus(struct ofono_sim *sim, ofono_sim_status_cb_t cb,
+                void *data);
+
 static void append_file_path(char *buf, const unsigned char *path,
 		unsigned int path_len)
 {
@@ -549,6 +552,50 @@ static void at_read_euiccid(struct ofono_sim *sim, ofono_sim_euiccid_cb_t cb,
 
 	g_free(cbd);
 	CALLBACK_WITH_FAILURE(cb, NULL, data);
+}
+
+static void at_sind_simstatus_read_cb(gboolean ok, GAtResult *result, gpointer user_data)
+{
+	struct cb_data *cbd = user_data;
+	GAtResultIter iter;
+	ofono_sim_status_cb_t cb = cbd->cb;
+	struct ofono_error error;
+	gint sim_stat;
+
+	decode_at_error(&error, g_at_result_final_response(result));
+	if (!ok) {
+		goto retry;
+	}
+
+	g_at_result_iter_init(&iter, result);
+	if (!g_at_result_iter_next(&iter, "^SIND: simstatus,"))
+		goto retry;
+
+	/* Skip mode since we are not interested in this */
+	if (!g_at_result_iter_skip_next(&iter))
+		goto retry;
+
+	if (!g_at_result_iter_next_number(&iter, &sim_stat))
+		goto retry;
+
+	cb(sim_stat, cbd->data); // Notify sim about status change => Ready
+	return;
+
+retry:
+	DBG("simstatus reported %d, doing retry", sim_stat);
+}
+
+static void at_read_simstatus(struct ofono_sim *sim, ofono_sim_status_cb_t cb,
+                void *data)
+{
+	struct sim_data *sd = ofono_sim_get_data(sim);
+	struct cb_data *cbd = cb_data_new(cb, data);
+
+	if(g_at_chat_send(sd->chat, "AT^SIND=\"simstatus\",1", sind_prefix,
+				at_sind_simstatus_read_cb, cbd, NULL) > 0)
+        	return;
+
+	g_free(cbd);
 }
 
 static struct {
@@ -2141,6 +2188,7 @@ static const struct ofono_sim_driver driver = {
 	.write_file_cyclic	= at_sim_update_cyclic,
 	.read_imsi		= at_read_imsi,
 	.read_euiccid		= at_read_euiccid,
+	.read_simstatus  	= at_read_simstatus,
 	.query_passwd_state	= at_pin_query,
 	.query_pin_retries	= at_pin_retries_query,
 	.send_passwd		= at_pin_send,

--- a/include/sim.h
+++ b/include/sim.h
@@ -101,6 +101,8 @@ typedef void (*ofono_sim_imsi_cb_t)(const struct ofono_error *error,
 typedef void (*ofono_sim_euiccid_cb_t)(const struct ofono_error *error,
 					const char *euiccid, void *data);
 
+typedef void (*ofono_sim_status_cb_t)(int simstatus, void *data);
+
 typedef void (*ofono_sim_state_event_cb_t)(enum ofono_sim_state new_state,
 					void *data);
 
@@ -170,6 +172,8 @@ struct ofono_sim_driver {
 			ofono_sim_imsi_cb_t cb, void *data);
 	void (*read_euiccid)(struct ofono_sim *sim,
 			ofono_sim_euiccid_cb_t cb, void *data);
+	void (*read_simstatus)(struct ofono_sim *sim, ofono_sim_status_cb_t cb,
+                	void *data);
 	void (*query_passwd_state)(struct ofono_sim *sim,
 			ofono_sim_passwd_cb_t cb, void *data);
 	void (*send_passwd)(struct ofono_sim *sim, const char *passwd,

--- a/plugins/gemalto.c
+++ b/plugins/gemalto.c
@@ -1892,6 +1892,7 @@ static void gemalto_ciev_simstatus_notify(GAtResultIter *iter, struct ofono_mode
 	}
 }
 
+#if 0
 static void gemalto_ciev_nitz_notify(GAtResultIter *iter,
 					struct ofono_modem *modem)
 {
@@ -1911,13 +1912,34 @@ static void gemalto_ciev_nitz_notify(GAtResultIter *iter,
 	gemalto_signal(GEMALTO_NITZ_TIME_INTERFACE, "NitzUpdated", nitz_data,
 									modem);
 }
+#endif
+
+// andriipe: added by Hans-Cristoph patch sim_refresh.patch
+static void gemalto_ciev_iccid_notify(GAtResultIter *iter, struct ofono_modem *modem)
+{
+	struct gemalto_data *data = ofono_modem_get_data(modem);
+	struct ofono_sim *sim = data->sim;
+	const char *iccid;
+
+	if (!g_at_result_iter_next_string(iter, &iccid))
+		return;
+
+	if (g_str_equal(iccid,"")){
+		DBG("SIM removed");
+		ofono_sim_inserted_notify(sim, FALSE);
+	} else {
+		DBG("Refreshing ICCID");
+		ofono_sim_inserted_notify(sim, TRUE);
+	}
+}
 
 static void gemalto_ciev_notify(GAtResult *result, gpointer user_data)
 {
 	struct ofono_modem *modem = user_data;
 
 	const char *sim_status = "simstatus";
-	const char *nitz_status = "nitz";
+//	const char *nitz_status = "nitz";
+	const char *iccid_status = "iccid";
 	const char *ind_str;
 	GAtResultIter iter;
 
@@ -1932,8 +1954,8 @@ static void gemalto_ciev_notify(GAtResult *result, gpointer user_data)
 
 	if (g_str_equal(sim_status, ind_str)) {
 		gemalto_ciev_simstatus_notify(&iter, modem);
-	} else if (g_str_equal(nitz_status, ind_str)) {
-		gemalto_ciev_nitz_notify(&iter, modem);
+	} else if (g_str_equal(iccid_status, ind_str)) {
+		gemalto_ciev_iccid_notify(&iter, modem);
 	}
 }
 
@@ -1960,9 +1982,8 @@ static void sim_state_cb(gboolean present, gpointer user_data)
 	g_at_chat_register(data->app, "+PBREADY",
 			gemalto_pbready_notify, FALSE, modem, NULL);
 
-	g_at_chat_send(data->app, "AT^SIND=\"simstatus\",1", none_prefix,
-			NULL, NULL, NULL);
-	g_at_chat_send(data->app, "AT^SIND=\"nitz\",1", none_prefix,
+	/* Turn ON iccid change indication */
+	g_at_chat_send(data->app, "AT^SIND=\"iccid\",1", none_prefix,
 			NULL, NULL, NULL);
 }
 

--- a/plugins/gemalto.c
+++ b/plugins/gemalto.c
@@ -1892,7 +1892,6 @@ static void gemalto_ciev_simstatus_notify(GAtResultIter *iter, struct ofono_mode
 	}
 }
 
-#if 0
 static void gemalto_ciev_nitz_notify(GAtResultIter *iter,
 					struct ofono_modem *modem)
 {
@@ -1912,7 +1911,6 @@ static void gemalto_ciev_nitz_notify(GAtResultIter *iter,
 	gemalto_signal(GEMALTO_NITZ_TIME_INTERFACE, "NitzUpdated", nitz_data,
 									modem);
 }
-#endif
 
 // andriipe: added by Hans-Cristoph patch sim_refresh.patch
 static void gemalto_ciev_iccid_notify(GAtResultIter *iter, struct ofono_modem *modem)
@@ -1938,7 +1936,7 @@ static void gemalto_ciev_notify(GAtResult *result, gpointer user_data)
 	struct ofono_modem *modem = user_data;
 
 	const char *sim_status = "simstatus";
-//	const char *nitz_status = "nitz";
+	const char *nitz_status = "nitz";
 	const char *iccid_status = "iccid";
 	const char *ind_str;
 	GAtResultIter iter;
@@ -1954,6 +1952,8 @@ static void gemalto_ciev_notify(GAtResult *result, gpointer user_data)
 
 	if (g_str_equal(sim_status, ind_str)) {
 		gemalto_ciev_simstatus_notify(&iter, modem);
+	} else if (g_str_equal(nitz_status, ind_str)) {
+		gemalto_ciev_nitz_notify(&iter, modem);
 	} else if (g_str_equal(iccid_status, ind_str)) {
 		gemalto_ciev_iccid_notify(&iter, modem);
 	}

--- a/src/sim.c
+++ b/src/sim.c
@@ -140,6 +140,7 @@ struct ofono_sim {
 	bool sdn_ready : 1;
 	bool initialized : 1;
 	bool wait_initialized : 1;
+	bool simstatus_ready : 1;
 };
 
 struct msisdn_set_request {
@@ -174,6 +175,7 @@ static const char *const passwd_name[] = {
 };
 
 static void sim_own_numbers_update(struct ofono_sim *sim);
+static void sim_initialize(struct ofono_sim *sim);
 
 static GSList *g_drivers = NULL;
 
@@ -1747,6 +1749,22 @@ static void  sim_retrieve_euiccid(struct ofono_sim *sim)
 		sim->driver->read_euiccid(sim, sim_euiccid_cb, sim);
 }
 
+static void sim_simstatus_cb(int simstatus, void *data)
+{
+	struct ofono_sim *sim = data;
+	DBG("ret : %d", simstatus);
+	if(simstatus >= 5)
+	{
+		sim->simstatus_ready = true;
+	}
+}
+
+static void  sim_retrieve_simstatus(struct ofono_sim *sim)
+{
+	if (sim->driver->read_simstatus)
+        	sim->driver->read_simstatus(sim, sim_simstatus_cb, sim);
+}
+
 static void sim_fdn_enabled(struct ofono_sim *sim)
 {
 	DBusConnection *conn = ofono_dbus_get_connection();
@@ -2267,13 +2285,25 @@ static void sim_iccid_read_cb(int ok, int length, int record,
 	const char *path = __ofono_atom_get_path(sim->atom);
 	DBusConnection *conn = ofono_dbus_get_connection();
 	char iccid[21]; /* ICCID max length is 20 + 1 for NULL */
+	static char read_retry = 0;
 
 	if (!ok || length < 10)
+	{
+		if(read_retry == 0) /* retry iccid read second time */
+		{
+			ofono_sim_read(sim->early_context, SIM_EF_ICCID_FILEID,
+				OFONO_SIM_FILE_STRUCTURE_TRANSPARENT,
+				sim_iccid_read_cb, sim);
+		}
+		read_retry = 1;
 		return;
+	}
 
 	extract_bcd_number(data, length, iccid);
 	iccid[20] = '\0';
 	sim->iccid = g_strdup(iccid);
+
+	DBG("iccid update: %s", iccid);
 
 	ofono_dbus_signal_property_changed(conn, path,
 						OFONO_SIM_MANAGER_INTERFACE,
@@ -2322,6 +2352,14 @@ static void sim_efli_efpl_changed(int id, void *userdata)
 			sim_efpl_read_cb, sim);
 }
 
+static gboolean sim_initialize_retry(gpointer userdata)
+{
+    struct ofono_sim *sim = userdata;
+    DBG("");
+    sim_initialize(sim);
+    return FALSE; // don't call automatically again
+}
+
 static void sim_initialize(struct ofono_sim *sim)
 {
 	/*
@@ -2352,6 +2390,19 @@ static void sim_initialize(struct ofono_sim *sim)
 
 	if (sim->early_context == NULL)
 		sim->early_context = ofono_sim_context_create(sim);
+
+	if (!sim->simstatus_ready)
+	{
+		DBG("Checking sim status");
+		sim_retrieve_simstatus(sim);
+		// Retry sim_initialize() in 3 seconds and check simstatus again
+		g_timeout_add_seconds(3, sim_initialize_retry, sim);
+		return;
+	}
+	else
+	{
+		DBG("simstatus is ready, go with initialize");
+	}
 
 	/* Grab the EFiccid which is always available */
 	ofono_sim_read(sim->early_context, SIM_EF_ICCID_FILEID,
@@ -2722,6 +2773,7 @@ static void sim_free_main_state(struct ofono_sim *sim)
 
 	sim->initialized = false;
 	sim->wait_initialized = false;
+	sim->simstatus_ready = false;
 }
 
 static void sim_free_state(struct ofono_sim *sim)
@@ -2816,12 +2868,15 @@ void ofono_sim_inserted_notify(struct ofono_sim *sim, ofono_bool_t inserted)
 		return;
 	}
 
-	if (inserted == TRUE && sim->state == OFONO_SIM_STATE_NOT_PRESENT)
+	if (inserted == TRUE && (sim->state == OFONO_SIM_STATE_NOT_PRESENT || sim->state == OFONO_SIM_STATE_READY))
 		sim->state = OFONO_SIM_STATE_INSERTED;
 	else if (inserted == FALSE && sim->state != OFONO_SIM_STATE_NOT_PRESENT)
 		sim->state = OFONO_SIM_STATE_NOT_PRESENT;
 	else
+	{
+		DBG("skipping sim status update, prev st: %d", sim->state);
 		return;
+	}
 
 	if (!__ofono_atom_get_registered(sim->atom))
 		return;


### PR DESCRIPTION
Added proper handling for SIM profile update network event in Gemalto driver.
Added retry for ICCID read.
Added wait for sim_status=ready before reading ICCID from SIM.
_Author: Andrii Perepytailo_